### PR TITLE
test: Google Safe Browsing 公式テストURLによる実APIテスト追加

### DIFF
--- a/api/safety/safebrowsing_integration_test.go
+++ b/api/safety/safebrowsing_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package safety
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSafeBrowsingIntegration(t *testing.T) {
+	apiKey := os.Getenv("GOOGLE_SAFE_BROWSING_API_KEY")
+	if apiKey == "" {
+		t.Skip("GOOGLE_SAFE_BROWSING_API_KEY not set")
+	}
+
+	client := NewSafeBrowsingClient(apiKey)
+
+	tests := []struct {
+		name       string
+		url        string
+		wantSafe   bool
+		wantDetail string
+	}{
+		{
+			name:       "malware test URL",
+			url:        "http://testsafebrowsing.appspot.com/s/malware.html",
+			wantSafe:   false,
+			wantDetail: "blocked: MALWARE",
+		},
+		{
+			name:       "phishing test URL",
+			url:        "http://testsafebrowsing.appspot.com/s/phishing.html",
+			wantSafe:   false,
+			wantDetail: "blocked: SOCIAL_ENGINEERING",
+		},
+		{
+			name:       "unwanted software test URL",
+			url:        "http://testsafebrowsing.appspot.com/s/unwanted.html",
+			wantSafe:   false,
+			wantDetail: "blocked: UNWANTED_SOFTWARE",
+		},
+		{
+			name:       "safe URL",
+			url:        "https://example.com",
+			wantSafe:   true,
+			wantDetail: "safe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			safe, detail, err := client.Check(tt.url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if safe != tt.wantSafe {
+				t.Errorf("safe = %v, want %v (detail: %s)", safe, tt.wantSafe, detail)
+			}
+			if detail != tt.wantDetail {
+				t.Errorf("detail = %q, want %q", detail, tt.wantDetail)
+			}
+		})
+	}
+}

--- a/e2e/tests/redirect.spec.ts
+++ b/e2e/tests/redirect.spec.ts
@@ -83,6 +83,41 @@ test.describe("Redirect - unsafe URL warning page", () => {
   });
 });
 
+test.describe("Real Safe Browsing integration", () => {
+  test("malware test URL is rejected by Safe Browsing API", async ({
+    request,
+  }) => {
+    const res = await request.post(`${API}/api/shorten`, {
+      data: { url: "http://testsafebrowsing.appspot.com/s/malware.html" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("unsafe URL");
+  });
+
+  test("phishing test URL is rejected by Safe Browsing API", async ({
+    request,
+  }) => {
+    const res = await request.post(`${API}/api/shorten`, {
+      data: { url: "http://testsafebrowsing.appspot.com/s/phishing.html" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("unsafe URL");
+  });
+
+  test("unwanted software test URL is rejected by Safe Browsing API", async ({
+    request,
+  }) => {
+    const res = await request.post(`${API}/api/shorten`, {
+      data: { url: "http://testsafebrowsing.appspot.com/s/unwanted.html" },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("unsafe URL");
+  });
+});
+
 test.describe("Health endpoint", () => {
   test("returns ok status", async ({ request }) => {
     const res = await request.get(`${API}/health`);


### PR DESCRIPTION
## Summary
- Google公式テストURL (`testsafebrowsing.appspot.com`) を使い、Safe Browsing APIが実際にmalware/phishing/unwanted softwareを検出することを検証
- Go インテグレーションテスト (`-tags=integration`) と Playwright E2Eテストの両方で追加

## Test plan
- [x] `go test ./...` (既存ユニットテスト) PASS
- [x] `go test -tags=integration ./safety/...` (実API) PASS — malware, phishing, unwanted software, safe URL すべて検証済み
- [x] `pnpm run build` (web) 成功