### PR TITLE
feat: OpenAPI spec 自動生成 + Swagger UI on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,43 @@
+name: Deploy Swagger UI to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/swagger.yaml"
+      - ".github/workflows/pages.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Swagger UI
+        run: |
+          SWAGGER_VERSION=$(curl -s https://api.github.com/repos/swagger-api/swagger-ui/releases/latest | jq -r .tag_name)
+          curl -sL "https://github.com/swagger-api/swagger-ui/archive/${SWAGGER_VERSION}.tar.gz" | tar xz
+          mkdir -p _site
+          cp -r swagger-ui-*/dist/* _site/
+          cp docs/swagger.yaml _site/
+          sed -i 's|https://petstore.swagger.io/v2/swagger.json|swagger.yaml|g' _site/swagger-initializer.js
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ url-shortener/
 
 ## APIの仕様
 
+📖 **[Swagger UI (API ドキュメント)](https://tommykey-apps.github.io/url-shortener/)**
+
 | Method | Path | 何するか |
 |--------|------|---------|
 | POST | `/api/shorten` | URLを短縮（DNS + Safe Browsing チェック付き） |

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -45,6 +45,17 @@ func NewWithDeps(s URLStore, c SafetyChecker) *Handler {
 	return &Handler{store: s, checker: c}
 }
 
+// Shorten godoc
+// @Summary URLを短縮
+// @Description URLを受け取り短縮コードを生成。DNS解決チェック + Google Safe Browsing APIで安全性を検証し、危険なURLは拒否する。
+// @Tags URLs
+// @Accept json
+// @Produce json
+// @Param request body model.ShortenRequest true "短縮したいURL"
+// @Success 201 {object} model.ShortenResponse
+// @Failure 400 {object} model.ErrorResponse
+// @Failure 500 {object} model.ErrorResponse
+// @Router /api/shorten [post]
 func (h *Handler) Shorten(w http.ResponseWriter, r *http.Request) {
 	var req model.ShortenRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -84,6 +95,15 @@ func (h *Handler) Shorten(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// Get godoc
+// @Summary URL詳細取得
+// @Tags URLs
+// @Produce json
+// @Param code path string true "短縮コード"
+// @Success 200 {object} model.URL
+// @Failure 404 {object} model.ErrorResponse
+// @Failure 500 {object} model.ErrorResponse
+// @Router /api/urls/{code} [get]
 func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 	code := r.PathValue("code")
 	u, err := h.store.Get(r.Context(), code)
@@ -98,6 +118,13 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, u)
 }
 
+// List godoc
+// @Summary URL一覧取得
+// @Tags URLs
+// @Produce json
+// @Success 200 {array} model.URL
+// @Failure 500 {object} model.ErrorResponse
+// @Router /api/urls [get]
 func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	urls, err := h.store.List(r.Context())
 	if err != nil {
@@ -107,6 +134,13 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, urls)
 }
 
+// Delete godoc
+// @Summary URL削除
+// @Tags URLs
+// @Param code path string true "短縮コード"
+// @Success 204 "削除成功"
+// @Failure 500 {object} model.ErrorResponse
+// @Router /api/urls/{code} [delete]
 func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	code := r.PathValue("code")
 	if err := h.store.Delete(r.Context(), code); err != nil {
@@ -116,6 +150,15 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// Redirect godoc
+// @Summary リダイレクト
+// @Description 短縮コードに対応する元URLへ301リダイレクト。クリック数をカウント。unsafe判定のURLは警告ページを表示。
+// @Tags Redirect
+// @Param code path string true "短縮コード"
+// @Success 301 "元URLへリダイレクト"
+// @Success 200 {string} string "unsafe URLの場合、警告ページを表示"
+// @Failure 404 "該当コードなし"
+// @Router /r/{code} [get]
 func (h *Handler) Redirect(w http.ResponseWriter, r *http.Request) {
 	code := r.PathValue("code")
 	u, err := h.store.Get(r.Context(), code)
@@ -144,6 +187,16 @@ func (h *Handler) Redirect(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, u.Original, http.StatusMovedPermanently)
 }
 
+// Summarize godoc
+// @Summary AIによるURL遷移先の要約
+// @Description 短縮URLの遷移先ページをAI (Groq / Llama 3.3 70B) で要約する。
+// @Tags AI
+// @Produce json
+// @Param code path string true "短縮コード"
+// @Success 200 {object} map[string]string
+// @Failure 404 {object} model.ErrorResponse
+// @Failure 500 {object} model.ErrorResponse
+// @Router /api/urls/{code}/summarize [post]
 func (h *Handler) Summarize(w http.ResponseWriter, r *http.Request) {
 	code := r.PathValue("code")
 	u, err := h.store.Get(r.Context(), code)
@@ -161,6 +214,12 @@ func (h *Handler) Summarize(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"summary": summary})
 }
 
+// Health godoc
+// @Summary ヘルスチェック
+// @Tags System
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Router /health [get]
 func (h *Handler) Health(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "version": "1.0.0"})
 }

--- a/api/main.go
+++ b/api/main.go
@@ -16,6 +16,13 @@ import (
 	"github.com/tommykey0925/url-shortener-api/store"
 )
 
+// @title URL Shortener API
+// @version 1.0.0
+// @description URL短縮 + クリック計測サービスのAPI。登録時にDNS解決・Google Safe Browsing・AIによる安全性チェックを実施。
+
+// @host url.tommykeyapp.com
+// @BasePath /
+
 func setupMux() http.Handler {
 	s := store.New()
 	checker := safety.NewChecker(os.Getenv("GOOGLE_SAFE_BROWSING_API_KEY"), os.Getenv("GROQ_API_KEY"))

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,0 +1,197 @@
+basePath: /
+definitions:
+  model.ErrorResponse:
+    properties:
+      error:
+        type: string
+    type: object
+  model.ShortenRequest:
+    properties:
+      url:
+        type: string
+    type: object
+  model.ShortenResponse:
+    properties:
+      code:
+        type: string
+      safe_status:
+        type: string
+      short_url:
+        type: string
+    type: object
+  model.URL:
+    properties:
+      clicks:
+        type: integer
+      code:
+        type: string
+      created_at:
+        type: string
+      original_url:
+        type: string
+      safe_status:
+        type: string
+    type: object
+host: url.tommykeyapp.com
+info:
+  contact: {}
+  description: URL短縮 + クリック計測サービスのAPI。登録時にDNS解決・Google Safe Browsing・AIによる安全性チェックを実施。
+  title: URL Shortener API
+  version: 1.0.0
+paths:
+  /api/shorten:
+    post:
+      consumes:
+      - application/json
+      description: URLを受け取り短縮コードを生成。DNS解決チェック + Google Safe Browsing APIで安全性を検証し、危険なURLは拒否する。
+      parameters:
+      - description: 短縮したいURL
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/model.ShortenRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/model.ShortenResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+      summary: URLを短縮
+      tags:
+      - URLs
+  /api/urls:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.URL'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+      summary: URL一覧取得
+      tags:
+      - URLs
+  /api/urls/{code}:
+    delete:
+      parameters:
+      - description: 短縮コード
+        in: path
+        name: code
+        required: true
+        type: string
+      responses:
+        "204":
+          description: 削除成功
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+      summary: URL削除
+      tags:
+      - URLs
+    get:
+      parameters:
+      - description: 短縮コード
+        in: path
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.URL'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+      summary: URL詳細取得
+      tags:
+      - URLs
+  /api/urls/{code}/summarize:
+    post:
+      description: 短縮URLの遷移先ページをAI (Groq / Llama 3.3 70B) で要約する。
+      parameters:
+      - description: 短縮コード
+        in: path
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/model.ErrorResponse'
+      summary: AIによるURL遷移先の要約
+      tags:
+      - AI
+  /health:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: ヘルスチェック
+      tags:
+      - System
+  /r/{code}:
+    get:
+      description: 短縮コードに対応する元URLへ301リダイレクト。クリック数をカウント。unsafe判定のURLは警告ページを表示。
+      parameters:
+      - description: 短縮コード
+        in: path
+        name: code
+        required: true
+        type: string
+      responses:
+        "200":
+          description: unsafe URLの場合、警告ページを表示
+          schema:
+            type: string
+        "301":
+          description: 元URLへリダイレクト
+        "404":
+          description: 該当コードなし
+      summary: リダイレクト
+      tags:
+      - Redirect
+swagger: "2.0"


### PR DESCRIPTION
## Summary
- Go ハンドラに swag アノテーション追加、`swag init` で `docs/swagger.yaml` を自動生成
- GitHub Pages ワークフロー追加（Swagger UI でAPI仕様を公開）
- README に Swagger UI へのリンク追加

## 変更内容
- `api/handler/handler.go` — 全7エンドポイントに swag アノテーション
- `api/main.go` — API メタ情報（タイトル、バージョン、ホスト）
- `docs/swagger.yaml` — swag が生成した Swagger 2.0 スペック
- `.github/workflows/pages.yaml` — Swagger UI を GitHub Pages にデプロイ
- `README.md` — API ドキュメントリンク追加

## spec 更新方法
```bash
cd api && swag init --output ../docs --outputTypes yaml
```

## Test plan
- [ ] `go vet ./...` / `go test ./...` パス済み
- [ ] GitHub Pages デプロイ後、Swagger UI で全エンドポイント表示確認
- [ ] Settings → Pages の Source を GitHub Actions に設定