### PR TITLE
fix: versions.tfのarchive provider重複を修正

### DIFF
--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/archive"
       version = "~> 2.0"
     }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "~> 2.0"
-    }
   }
 }
 


### PR DESCRIPTION
マージ時にarchive providerが重複。terraform init/planが失敗する。