### PR TITLE
fix: CDのdeploy-webからflox依存を削除

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -87,17 +87,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
-      - uses: flox/install-flox-action@main
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Build SvelteKit
-        run: |
-          flox activate -- bash -c '
-            cd web
-            pnpm install --frozen-lockfile
-            pnpm build
-          '
+        run: cd web && pnpm install --frozen-lockfile && pnpm build
 
       - name: Deploy to S3
         run: aws s3 sync web/build/ s3://${{ secrets.FRONTEND_BUCKET }} --delete


### PR DESCRIPTION
nix + floxのインストールが遅いため、CIと同じpnpm + node直接に変更