### PR TITLE
fix: aws_caller_identity data sourceを追加

### DIFF
--- a/infra/ssm.tf
+++ b/infra/ssm.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_ssm_parameter" "cloudfront_distribution_id" {
   name  = "/${var.project}/cloudfront-distribution-id"
   type  = "String"


### PR DESCRIPTION
irsa.tf削除時に消えたdata sourceを復元