### PR TITLE
fix: CD の deploy-infra 条件を paths-filter で正しく判定

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,9 +17,23 @@ permissions:
   contents: read
 
 jobs:
-  deploy-infra:
+  detect-changes:
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.modified, 'infra/') || github.event_name == 'workflow_dispatch'
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+
+  deploy-infra:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- \`github.event.head_commit.modified\` が 2019 年廃止済みで push payload に存在せず、\`contains()\` が常に false になり \`deploy-infra\` が全スキップされていた
- \`dorny/paths-filter@v3\` を使う前段 \`detect-changes\` ジョブを追加し、\`infra/**\` の変更検出結果を \`deploy-infra\` の if に使う
- \`workflow_dispatch\` は手動フォールバックとして残す

## Context
過去 20 件の CD 実行で \`deploy-infra\` は skipped 19 / failure 1 / **success 0**。tommykey-apps/chat#113 と同じ問題・同じ修正。

fixes #28

## Test plan
- [ ] マージ後、次に infra/ を触る PR で deploy-infra が success することを確認
- [ ] 必要に応じて workflow_dispatch で現状 diff を plan ログから確認