### PR TITLE
feat: クリック統計API実装（Store + Handler + テスト）

### DIFF
--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/tommykey-apps/url-shortener-api/model"
 	"github.com/tommykey-apps/url-shortener-api/safety"
@@ -24,7 +25,10 @@ type URLStore interface {
 	List(ctx context.Context) ([]model.URL, error)
 	Delete(ctx context.Context, code string) error
 	IncrementClicks(ctx context.Context, code string) error
+	GetClickStats(ctx context.Context, code string, days int) ([]model.DailyClicks, error)
 }
+
+type DailyClicks = model.DailyClicks
 
 // SafetyChecker is the interface for URL safety checking.
 type SafetyChecker interface {
@@ -212,6 +216,50 @@ func (h *Handler) Summarize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"summary": summary})
+}
+
+// Stats godoc
+// @Summary クリック統計取得
+// @Description 短縮URLの日別クリック統計を取得する。デフォルトは過去30日分。
+// @Tags URLs
+// @Produce json
+// @Param code path string true "短縮コード"
+// @Param days query int false "取得日数（デフォルト30）"
+// @Success 200 {object} model.ClickStats
+// @Failure 404 {object} model.ErrorResponse
+// @Failure 500 {object} model.ErrorResponse
+// @Router /api/urls/{code}/stats [get]
+func (h *Handler) Stats(w http.ResponseWriter, r *http.Request) {
+	code := r.PathValue("code")
+	u, err := h.store.Get(r.Context(), code)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, model.ErrorResponse{Error: "not found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, model.ErrorResponse{Error: "internal error"})
+		return
+	}
+
+	days := 30
+	if d := r.URL.Query().Get("days"); d != "" {
+		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 && parsed <= 365 {
+			days = parsed
+		}
+	}
+
+	daily, err := h.store.GetClickStats(r.Context(), code, days)
+	if err != nil {
+		log.Printf("ERROR: GetClickStats failed: %v", err)
+		writeJSON(w, http.StatusInternalServerError, model.ErrorResponse{Error: "failed to get stats"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, model.ClickStats{
+		Code:        code,
+		TotalClicks: u.Clicks,
+		Daily:       daily,
+	})
 }
 
 // Health godoc

--- a/api/handler/handler_test.go
+++ b/api/handler/handler_test.go
@@ -62,6 +62,16 @@ func (m *mockStore) IncrementClicks(ctx context.Context, code string) error {
 	return nil
 }
 
+func (m *mockStore) GetClickStats(ctx context.Context, code string, days int) ([]model.DailyClicks, error) {
+	if _, ok := m.urls[code]; !ok {
+		return nil, nil
+	}
+	return []model.DailyClicks{
+		{Date: "2026-04-17", Clicks: 5},
+		{Date: "2026-04-16", Clicks: 3},
+	}, nil
+}
+
 // --- Mock Checker ---
 
 type mockChecker struct {
@@ -342,6 +352,44 @@ func TestSummarize_AIError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestStats_Success(t *testing.T) {
+	s := newMockStore()
+	s.urls["abc"] = &model.URL{Code: "abc", Original: "https://example.com", Clicks: 8}
+	h := NewWithDeps(s, &mockChecker{})
+
+	req := httptest.NewRequest("GET", "/api/urls/abc/stats", nil)
+	req.SetPathValue("code", "abc")
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp model.ClickStats
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.TotalClicks != 8 {
+		t.Errorf("expected 8 total clicks, got %d", resp.TotalClicks)
+	}
+	if len(resp.Daily) != 2 {
+		t.Errorf("expected 2 daily entries, got %d", len(resp.Daily))
+	}
+}
+
+func TestStats_NotFound(t *testing.T) {
+	h := NewWithDeps(newMockStore(), &mockChecker{})
+
+	req := httptest.NewRequest("GET", "/api/urls/nope/stats", nil)
+	req.SetPathValue("code", "nope")
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
 	}
 }
 

--- a/api/main.go
+++ b/api/main.go
@@ -34,6 +34,7 @@ func setupMux() http.Handler {
 	mux.HandleFunc("GET /api/urls/{code}", h.Get)
 	mux.HandleFunc("DELETE /api/urls/{code}", h.Delete)
 	mux.HandleFunc("POST /api/urls/{code}/summarize", h.Summarize)
+	mux.HandleFunc("GET /api/urls/{code}/stats", h.Stats)
 	mux.HandleFunc("GET /r/{code}", h.Redirect)
 	mux.HandleFunc("GET /health", h.Health)
 

--- a/api/store/store.go
+++ b/api/store/store.go
@@ -93,6 +93,9 @@ func (s *Store) Get(ctx context.Context, code string) (*model.URL, error) {
 }
 
 func (s *Store) IncrementClicks(ctx context.Context, code string) error {
+	today := time.Now().UTC().Format("2006-01-02")
+
+	// Update total clicks
 	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: &s.tableName,
 		Key: map[string]types.AttributeValue{
@@ -103,7 +106,51 @@ func (s *Store) IncrementClicks(ctx context.Context, code string) error {
 			":inc": &types.AttributeValueMemberN{Value: "1"},
 		},
 	})
+	if err != nil {
+		return err
+	}
+
+	// Record daily click in stats table
+	statsTable := s.tableName + "-stats"
+	_, err = s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: &statsTable,
+		Key: map[string]types.AttributeValue{
+			"code": &types.AttributeValueMemberS{Value: code},
+			"date": &types.AttributeValueMemberS{Value: today},
+		},
+		UpdateExpression: aws.String("SET clicks = if_not_exists(clicks, :zero) + :inc"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":inc":  &types.AttributeValueMemberN{Value: "1"},
+			":zero": &types.AttributeValueMemberN{Value: "0"},
+		},
+	})
 	return err
+}
+
+func (s *Store) GetClickStats(ctx context.Context, code string, days int) ([]model.DailyClicks, error) {
+	statsTable := s.tableName + "-stats"
+	startDate := time.Now().UTC().AddDate(0, 0, -days).Format("2006-01-02")
+
+	out, err := s.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              &statsTable,
+		KeyConditionExpression: aws.String("code = :code AND #d >= :start"),
+		ExpressionAttributeNames: map[string]string{
+			"#d": "date",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":code":  &types.AttributeValueMemberS{Value: code},
+			":start": &types.AttributeValueMemberS{Value: startDate},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query stats: %w", err)
+	}
+
+	var stats []model.DailyClicks
+	if err := attributevalue.UnmarshalListOfMaps(out.Items, &stats); err != nil {
+		return nil, fmt.Errorf("unmarshal stats: %w", err)
+	}
+	return stats, nil
 }
 
 func (s *Store) UpdateSafeStatus(ctx context.Context, code, status string) error {


### PR DESCRIPTION
## Summary
- `Store.IncrementClicks` に日別クリック記録を追加（stats テーブル）
- `Store.GetClickStats` で日別統計を取得する Query 実装
- `Handler.Stats` エンドポイント + `GET /api/urls/{code}/stats` ルート登録
- モック更新 + `TestStats_Success` / `TestStats_NotFound` テスト追加

## Stack
- PR #1: モデル定義（ClickStats, DailyClicks）
- **PR #2: API実装（Store + Handler + ルーティング + テスト）** <- this
- PR #3: Web UI（API クライアント + 統計ダイアログ）