### PR TITLE
fix: CD から TF_VAR で API キーを Lambda に注入 (fixes #36)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,6 +46,9 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Apply
+        env:
+          TF_VAR_groq_api_key: ${{ secrets.GROQ_API_KEY }}
+          TF_VAR_google_safe_browsing_api_key: ${{ secrets.GOOGLE_SAFE_BROWSING_API_KEY }}
         run: |
           cd infra
           terraform init

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -207,6 +207,7 @@ func (h *Handler) Summarize(w http.ResponseWriter, r *http.Request) {
 
 	summary, err := h.checker.Summarize(u.Original)
 	if err != nil {
+		log.Printf("ERROR: AI summarize failed for code=%s: %v", code, err)
 		writeJSON(w, http.StatusInternalServerError, model.ErrorResponse{Error: "AI summarization failed"})
 		return
 	}

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -28,11 +28,11 @@ resource "aws_lambda_function" "api" {
 
   environment {
     variables = {
-      DYNAMODB_TABLE                = aws_dynamodb_table.urls.name
-      AWS_REGION_APP                = var.region
-      BASE_URL                      = "https://url.tommykeyapp.com"
-      GOOGLE_SAFE_BROWSING_API_KEY  = var.google_safe_browsing_api_key
-      GROQ_API_KEY                  = var.groq_api_key
+      DYNAMODB_TABLE               = aws_dynamodb_table.urls.name
+      AWS_REGION_APP               = var.region
+      BASE_URL                     = "https://url.tommykeyapp.com"
+      GOOGLE_SAFE_BROWSING_API_KEY = var.google_safe_browsing_api_key
+      GROQ_API_KEY                 = var.groq_api_key
     }
   }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -11,15 +11,13 @@ variable "project" {
 }
 
 variable "google_safe_browsing_api_key" {
-  description = "Google Safe Browsing API key"
+  description = "Google Safe Browsing API key (set via TF_VAR_google_safe_browsing_api_key from CD)"
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 variable "groq_api_key" {
-  description = "Groq API key for AI safety prediction"
+  description = "Groq API key for AI summarization (set via TF_VAR_groq_api_key from CD)"
   type        = string
   sensitive   = true
-  default     = ""
 }


### PR DESCRIPTION
## Summary

- 本番 Lambda の \`GROQ_API_KEY\` / \`GOOGLE_SAFE_BROWSING_API_KEY\` が空で AI 要約 / Safe Browsing が動いていなかった問題を修正
- 2026-04-06 の infra 系 PR マージで走った CD の \`terraform apply\` が、default=\"\" の変数値で Lambda env var を上書きしたのが原因（詳細は #36）
- CD ワークフローで GitHub Actions Secrets を TF_VAR として terraform に渡すように変更
- \`infra/variables.tf\` の default=\"\" を削除し、CD で値を渡し忘れたら apply が明示失敗する防波堤を設置
- \`api/handler/handler.go\` の AI エラーに log.Printf を追加（これまで握り潰されて CloudWatch に痕跡がなかった）

## Test plan

- [x] \`terraform fmt -check\` / \`terraform validate\` 通過
- [x] \`go vet ./...\` / \`go test ./handler/...\` 通過
- [x] GitHub Actions Secrets (\`GROQ_API_KEY\`, \`GOOGLE_SAFE_BROWSING_API_KEY\`) 登録済み確認
- [ ] マージ後、CD の deploy-infra が成功
- [ ] \`aws lambda get-function-configuration --function-name url-shortener-api --query 'Environment.Variables.GROQ_API_KEY'\` が空でないことを確認
- [ ] https://url.tommykeyapp.com で任意の短縮 URL の「AI要約」ボタン → 実要約が返る
- [ ] 不審 URL を短縮しようとして Safe Browsing 警告が出る

fixes #36