### PR TITLE
feat: URL クリック統計機能（モデル + API + Web UI、stats table 含む）

### DIFF
--- a/api/cmd/monitor/monitor_integration_test.go
+++ b/api/cmd/monitor/monitor_integration_test.go
@@ -54,7 +54,7 @@ func setupMonitorTestStore(t *testing.T) *store.Store {
 		BillingMode: types.BillingModePayPerRequest,
 	})
 
-	s := store.NewWithClient(client, testTableName)
+	s := store.NewWithClient(client, testTableName, testTableName+"-stats")
 	items, _ := s.List(ctx)
 	for _, item := range items {
 		_ = s.Delete(ctx, item.Code)

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/tommykey-apps/url-shortener-api/model"
 	"github.com/tommykey-apps/url-shortener-api/safety"
@@ -24,6 +25,7 @@ type URLStore interface {
 	List(ctx context.Context) ([]model.URL, error)
 	Delete(ctx context.Context, code string) error
 	IncrementClicks(ctx context.Context, code string) error
+	GetClickStats(ctx context.Context, code string, days int) ([]model.DailyClicks, error)
 }
 
 // SafetyChecker is the interface for URL safety checking.
@@ -213,6 +215,50 @@ func (h *Handler) Summarize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"summary": summary})
+}
+
+// Stats godoc
+// @Summary クリック統計取得
+// @Description 短縮URLの日別クリック統計を取得する。デフォルトは過去30日分、最大365日。
+// @Tags URLs
+// @Produce json
+// @Param code path string true "短縮コード"
+// @Param days query int false "取得日数（デフォルト30、最大365）"
+// @Success 200 {object} model.ClickStats
+// @Failure 404 {object} model.ErrorResponse
+// @Failure 500 {object} model.ErrorResponse
+// @Router /api/urls/{code}/stats [get]
+func (h *Handler) Stats(w http.ResponseWriter, r *http.Request) {
+	code := r.PathValue("code")
+	u, err := h.store.Get(r.Context(), code)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, model.ErrorResponse{Error: "not found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, model.ErrorResponse{Error: "internal error"})
+		return
+	}
+
+	days := 30
+	if d := r.URL.Query().Get("days"); d != "" {
+		if parsed, err := strconv.Atoi(d); err == nil && parsed > 0 && parsed <= 365 {
+			days = parsed
+		}
+	}
+
+	daily, err := h.store.GetClickStats(r.Context(), code, days)
+	if err != nil {
+		log.Printf("ERROR: GetClickStats failed for code=%s: %v", code, err)
+		writeJSON(w, http.StatusInternalServerError, model.ErrorResponse{Error: "failed to get stats"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, model.ClickStats{
+		Code:        code,
+		TotalClicks: u.Clicks,
+		Daily:       daily,
+	})
 }
 
 // Health godoc

--- a/api/handler/handler_test.go
+++ b/api/handler/handler_test.go
@@ -62,6 +62,16 @@ func (m *mockStore) IncrementClicks(ctx context.Context, code string) error {
 	return nil
 }
 
+func (m *mockStore) GetClickStats(ctx context.Context, code string, days int) ([]model.DailyClicks, error) {
+	if _, ok := m.urls[code]; !ok {
+		return nil, nil
+	}
+	return []model.DailyClicks{
+		{Date: "2026-04-28", Clicks: 5},
+		{Date: "2026-04-27", Clicks: 3},
+	}, nil
+}
+
 // --- Mock Checker ---
 
 type mockChecker struct {
@@ -342,6 +352,67 @@ func TestSummarize_AIError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestStats_Success(t *testing.T) {
+	s := newMockStore()
+	s.urls["abc"] = &model.URL{Code: "abc", Original: "https://example.com", Clicks: 8}
+	h := NewWithDeps(s, &mockChecker{})
+
+	req := httptest.NewRequest("GET", "/api/urls/abc/stats", nil)
+	req.SetPathValue("code", "abc")
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp model.ClickStats
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Code != "abc" {
+		t.Errorf("expected code 'abc', got %q", resp.Code)
+	}
+	if resp.TotalClicks != 8 {
+		t.Errorf("expected 8 total clicks, got %d", resp.TotalClicks)
+	}
+	if len(resp.Daily) != 2 {
+		t.Errorf("expected 2 daily entries, got %d", len(resp.Daily))
+	}
+}
+
+func TestStats_NotFound(t *testing.T) {
+	h := NewWithDeps(newMockStore(), &mockChecker{})
+
+	req := httptest.NewRequest("GET", "/api/urls/nope/stats", nil)
+	req.SetPathValue("code", "nope")
+	w := httptest.NewRecorder()
+
+	h.Stats(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestStats_DaysQuery(t *testing.T) {
+	s := newMockStore()
+	s.urls["abc"] = &model.URL{Code: "abc", Original: "https://example.com"}
+	h := NewWithDeps(s, &mockChecker{})
+
+	// 不正な days パラメータでもエラーにならず default 30 として扱われる
+	cases := []string{"", "abc", "0", "-1", "9999", "30", "7"}
+	for _, q := range cases {
+		req := httptest.NewRequest("GET", "/api/urls/abc/stats?days="+q, nil)
+		req.SetPathValue("code", "abc")
+		w := httptest.NewRecorder()
+
+		h.Stats(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("days=%q: expected 200, got %d", q, w.Code)
+		}
 	}
 }
 

--- a/api/main.go
+++ b/api/main.go
@@ -34,6 +34,7 @@ func setupMux() http.Handler {
 	mux.HandleFunc("GET /api/urls/{code}", h.Get)
 	mux.HandleFunc("DELETE /api/urls/{code}", h.Delete)
 	mux.HandleFunc("POST /api/urls/{code}/summarize", h.Summarize)
+	mux.HandleFunc("GET /api/urls/{code}/stats", h.Stats)
 	mux.HandleFunc("GET /r/{code}", h.Redirect)
 	mux.HandleFunc("GET /health", h.Health)
 

--- a/api/model/url.go
+++ b/api/model/url.go
@@ -23,3 +23,14 @@ type ShortenResponse struct {
 type ErrorResponse struct {
 	Error string `json:"error"`
 }
+
+type DailyClicks struct {
+	Date   string `json:"date" dynamodbav:"date"`
+	Clicks int64  `json:"clicks" dynamodbav:"clicks"`
+}
+
+type ClickStats struct {
+	Code        string        `json:"code"`
+	TotalClicks int64         `json:"total_clicks"`
+	Daily       []DailyClicks `json:"daily"`
+}

--- a/api/store/store.go
+++ b/api/store/store.go
@@ -18,14 +18,19 @@ import (
 var ErrNotFound = errors.New("url not found")
 
 type Store struct {
-	client    *dynamodb.Client
-	tableName string
+	client         *dynamodb.Client
+	tableName      string
+	statsTableName string
 }
 
 func New() *Store {
 	tableName := os.Getenv("DYNAMODB_TABLE")
 	if tableName == "" {
 		tableName = "url-shortener"
+	}
+	statsTableName := os.Getenv("DYNAMODB_STATS_TABLE")
+	if statsTableName == "" {
+		statsTableName = tableName + "-stats"
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background())
@@ -34,15 +39,17 @@ func New() *Store {
 	}
 
 	return &Store{
-		client:    dynamodb.NewFromConfig(cfg),
-		tableName: tableName,
+		client:         dynamodb.NewFromConfig(cfg),
+		tableName:      tableName,
+		statsTableName: statsTableName,
 	}
 }
 
-func NewWithClient(client *dynamodb.Client, tableName string) *Store {
+func NewWithClient(client *dynamodb.Client, tableName, statsTableName string) *Store {
 	return &Store{
-		client:    client,
-		tableName: tableName,
+		client:         client,
+		tableName:      tableName,
+		statsTableName: statsTableName,
 	}
 }
 
@@ -103,7 +110,53 @@ func (s *Store) IncrementClicks(ctx context.Context, code string) error {
 			":inc": &types.AttributeValueMemberN{Value: "1"},
 		},
 	})
-	return err
+	if err != nil {
+		return fmt.Errorf("update url clicks: %w", err)
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+	_, err = s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: &s.statsTableName,
+		Key: map[string]types.AttributeValue{
+			"code": &types.AttributeValueMemberS{Value: code},
+			"date": &types.AttributeValueMemberS{Value: today},
+		},
+		UpdateExpression: aws.String("SET clicks = if_not_exists(clicks, :zero) + :inc"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":inc":  &types.AttributeValueMemberN{Value: "1"},
+			":zero": &types.AttributeValueMemberN{Value: "0"},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("update daily stats: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetClickStats(ctx context.Context, code string, days int) ([]model.DailyClicks, error) {
+	startDate := time.Now().UTC().AddDate(0, 0, -days).Format("2006-01-02")
+
+	out, err := s.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              &s.statsTableName,
+		KeyConditionExpression: aws.String("code = :code AND #d >= :start"),
+		ExpressionAttributeNames: map[string]string{
+			"#d": "date",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":code":  &types.AttributeValueMemberS{Value: code},
+			":start": &types.AttributeValueMemberS{Value: startDate},
+		},
+		ScanIndexForward: aws.Bool(false), // 降順 (新しい日付から)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query stats: %w", err)
+	}
+
+	stats := make([]model.DailyClicks, 0, len(out.Items))
+	if err := attributevalue.UnmarshalListOfMaps(out.Items, &stats); err != nil {
+		return nil, fmt.Errorf("unmarshal stats: %w", err)
+	}
+	return stats, nil
 }
 
 func (s *Store) UpdateSafeStatus(ctx context.Context, code, status string) error {

--- a/api/store/store_integration_test.go
+++ b/api/store/store_integration_test.go
@@ -5,6 +5,7 @@ package store
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -13,7 +14,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-const testTableName = "url-shortener-test"
+const (
+	testTableName      = "url-shortener-test"
+	testStatsTableName = "url-shortener-test-stats"
+)
 
 func setupTestStore(t *testing.T) *Store {
 	t.Helper()
@@ -31,7 +35,7 @@ func setupTestStore(t *testing.T) *Store {
 		o.BaseEndpoint = aws.String("http://localhost:8000")
 	})
 
-	// Create table (ignore error if already exists)
+	// Create urls table (ignore error if already exists)
 	_, _ = client.CreateTable(ctx, &dynamodb.CreateTableInput{
 		TableName: aws.String(testTableName),
 		KeySchema: []types.KeySchemaElement{
@@ -43,11 +47,38 @@ func setupTestStore(t *testing.T) *Store {
 		BillingMode: types.BillingModePayPerRequest,
 	})
 
-	// Clean up existing items
-	s := NewWithClient(client, testTableName)
+	// Create stats table (composite key: code + date)
+	_, _ = client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(testStatsTableName),
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("code"), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String("date"), KeyType: types.KeyTypeRange},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("code"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("date"), AttributeType: types.ScalarAttributeTypeS},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+
+	s := NewWithClient(client, testTableName, testStatsTableName)
+
+	// Clean up existing items in urls
 	items, _ := s.List(ctx)
 	for _, item := range items {
 		_ = s.Delete(ctx, item.Code)
+	}
+
+	// Clean up existing items in stats
+	statsScan, _ := client.Scan(ctx, &dynamodb.ScanInput{TableName: aws.String(testStatsTableName)})
+	for _, it := range statsScan.Items {
+		_, _ = client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+			TableName: aws.String(testStatsTableName),
+			Key: map[string]types.AttributeValue{
+				"code": it["code"],
+				"date": it["date"],
+			},
+		})
 	}
 
 	return s
@@ -162,6 +193,35 @@ func TestIntegration_IncrementClicks(t *testing.T) {
 		t.Fatalf("Get after clicks failed: %v", err)
 	}
 	if got.Clicks != 3 {
-		t.Errorf("expected 3 clicks, got %d", got.Clicks)
+		t.Errorf("expected 3 clicks on urls table, got %d", got.Clicks)
+	}
+
+	// stats table にも同期して書かれているか
+	stats, err := s.GetClickStats(ctx, "click001", 1)
+	if err != nil {
+		t.Fatalf("GetClickStats failed: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 daily entry today, got %d", len(stats))
+	}
+	today := time.Now().UTC().Format("2006-01-02")
+	if stats[0].Date != today {
+		t.Errorf("expected today's date %s, got %s", today, stats[0].Date)
+	}
+	if stats[0].Clicks != 3 {
+		t.Errorf("expected 3 daily clicks today, got %d", stats[0].Clicks)
+	}
+}
+
+func TestIntegration_GetClickStats_Empty(t *testing.T) {
+	s := setupTestStore(t)
+	ctx := context.Background()
+
+	stats, err := s.GetClickStats(ctx, "nonexistent", 30)
+	if err != nil {
+		t.Fatalf("GetClickStats should not error on missing code: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(stats))
 	}
 }

--- a/infra/dynamodb.tf
+++ b/infra/dynamodb.tf
@@ -14,3 +14,24 @@ resource "aws_dynamodb_table" "urls" {
     Project = var.project
   }
 }
+
+resource "aws_dynamodb_table" "urls_stats" {
+  name         = "${var.project}-stats"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "code"
+  range_key    = "date"
+
+  attribute {
+    name = "code"
+    type = "S"
+  }
+
+  attribute {
+    name = "date"
+    type = "S"
+  }
+
+  tags = {
+    Project = var.project
+  }
+}

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -29,6 +29,7 @@ resource "aws_lambda_function" "api" {
   environment {
     variables = {
       DYNAMODB_TABLE               = aws_dynamodb_table.urls.name
+      DYNAMODB_STATS_TABLE         = aws_dynamodb_table.urls_stats.name
       AWS_REGION_APP               = var.region
       BASE_URL                     = "https://url.tommykeyapp.com"
       GOOGLE_SAFE_BROWSING_API_KEY = var.google_safe_browsing_api_key
@@ -85,8 +86,12 @@ resource "aws_iam_role_policy" "lambda_dynamodb" {
           "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
           "dynamodb:Scan",
+          "dynamodb:Query",
         ]
-        Resource = aws_dynamodb_table.urls.arn
+        Resource = [
+          aws_dynamodb_table.urls.arn,
+          aws_dynamodb_table.urls_stats.arn,
+        ]
       }
     ]
   })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -40,3 +40,20 @@ export async function summarizeUrl(code: string): Promise<string> {
 	const data = await res.json();
 	return data.summary;
 }
+
+export interface DailyClicks {
+	date: string;
+	clicks: number;
+}
+
+export interface ClickStats {
+	code: string;
+	total_clicks: number;
+	daily: DailyClicks[];
+}
+
+export async function getClickStats(code: string, days = 30): Promise<ClickStats> {
+	const res = await fetch(`/api/urls/${code}/stats?days=${days}`);
+	if (!res.ok) throw new Error('Failed to fetch stats');
+	return res.json();
+}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { shortenUrl, listUrls, deleteUrl, summarizeUrl, type URL as ShortURL, type ShortenResponse } from '$lib/api';
+	import { shortenUrl, listUrls, deleteUrl, summarizeUrl, getClickStats, type URL as ShortURL, type ShortenResponse, type ClickStats } from '$lib/api';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import * as Card from '$lib/components/ui/card';
@@ -17,6 +17,9 @@
 	let summarizing = $state('');
 	let summaryText = $state('');
 	let showSummary = $state(false);
+	let statsLoading = $state('');
+	let statsData = $state<ClickStats | null>(null);
+	let showStats = $state(false);
 
 	function getMyCodes(): string[] {
 		try {
@@ -94,6 +97,19 @@
 			showSummary = true;
 		} finally {
 			summarizing = '';
+		}
+	}
+
+	async function handleStats(code: string) {
+		statsLoading = code;
+		statsData = null;
+		try {
+			statsData = await getClickStats(code);
+			showStats = true;
+		} catch {
+			error = '統計の取得に失敗しました';
+		} finally {
+			statsLoading = '';
 		}
 	}
 
@@ -200,6 +216,14 @@
 									<Button
 										variant="ghost"
 										size="sm"
+										disabled={statsLoading === url.code}
+										onclick={() => handleStats(url.code)}
+									>
+										{statsLoading === url.code ? '読込中...' : '統計'}
+									</Button>
+									<Button
+										variant="ghost"
+										size="sm"
 										disabled={summarizing === url.code}
 										onclick={() => handleSummarize(url.code)}
 									>
@@ -248,6 +272,14 @@
 								<Button
 									variant="ghost"
 									size="sm"
+									disabled={statsLoading === url.code}
+									onclick={() => handleStats(url.code)}
+								>
+									{statsLoading === url.code ? '読込中...' : '統計'}
+								</Button>
+								<Button
+									variant="ghost"
+									size="sm"
 									disabled={summarizing === url.code}
 									onclick={() => handleSummarize(url.code)}
 								>
@@ -283,6 +315,51 @@
 		</div>
 		<Dialog.Footer>
 			<Button variant="secondary" onclick={() => (showSummary = false)}>閉じる</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>
+
+<!-- Click Stats Dialog -->
+<Dialog.Root bind:open={showStats}>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>クリック統計 — <span class="font-mono">{statsData?.code}</span></Dialog.Title>
+		</Dialog.Header>
+		{#if statsData}
+			<div class="space-y-4">
+				<div class="text-center">
+					<p class="text-3xl font-bold text-primary">{statsData.total_clicks}</p>
+					<p class="text-sm text-muted-foreground">総クリック数</p>
+				</div>
+				{#if statsData.daily.length > 0}
+					<div>
+						<p class="mb-2 text-sm font-medium">日別クリック数（過去30日）</p>
+						<div class="max-h-60 overflow-y-auto rounded border">
+							<Table.Root>
+								<Table.Header>
+									<Table.Row>
+										<Table.Head>日付</Table.Head>
+										<Table.Head class="text-right">クリック数</Table.Head>
+									</Table.Row>
+								</Table.Header>
+								<Table.Body>
+									{#each statsData.daily as d (d.date)}
+										<Table.Row>
+											<Table.Cell class="font-mono">{d.date}</Table.Cell>
+											<Table.Cell class="text-right">{d.clicks}</Table.Cell>
+										</Table.Row>
+									{/each}
+								</Table.Body>
+							</Table.Root>
+						</div>
+					</div>
+				{:else}
+					<p class="text-center text-sm text-muted-foreground">過去30日間のクリック履歴がありません</p>
+				{/if}
+			</div>
+		{/if}
+		<Dialog.Footer>
+			<Button variant="secondary" onclick={() => (showStats = false)}>閉じる</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
## Summary

過去の stack PR #33 (model) + #34 (API) + #35 (Web UI) を **origin/main 起点のクリーン実装で 1 PR にまとめて再構築**。旧実装の致命バグ「stats table が IaC で provision されていない」も同時に修正。

## Background

- 旧 stack PR の中 #34 / #35 は一度 main に merge されたが、main の history rewrite で消失。#33 だけ open のまま放置されていた (#40 issue 参照)。
- 旧 #34 の \`Store.IncrementClicks\` は \`<tablename>-stats\` テーブルへ upsert していたが、その stats table の terraform 定義もテストセットアップも無かったため integration test \`TestIntegration_IncrementClicks\` が常時失敗していた。
- cherry-pick 復元ではなく、現在の main の状態に合わせてクリーン実装する方針を採用 (\`#33\` close 後に置換予定)。

## Changes

### infra
- \`infra/dynamodb.tf\`: \`aws_dynamodb_table.urls_stats\` 新設 (HASH=code, RANGE=date, PAY_PER_REQUEST)
- \`infra/lambda.tf\`: IAM policy に stats table の操作権限と \`dynamodb:Query\` 追加、Lambda env に \`DYNAMODB_STATS_TABLE\` 追加

### backend (Go)
- \`api/model/url.go\`: \`ClickStats\` / \`DailyClicks\` 型を追加
- \`api/store/store.go\`: Store に \`statsTableName\` フィールド追加、\`IncrementClicks\` を urls + stats 両 table 更新に拡張、\`GetClickStats\` 新設 (Query で日付降順)
- \`api/handler/handler.go\`: \`URLStore\` interface に \`GetClickStats\` 追加、\`Stats\` handler 新設 (\`GET /api/urls/{code}/stats?days=N\`、default 30、最大 365)
- \`api/main.go\`: ルート登録
- \`api/cmd/monitor/monitor_integration_test.go\`: \`NewWithClient\` の signature 変更に追従

### backend test
- \`api/store/store_integration_test.go\`: \`setupTestStore\` で stats table も provision、\`TestIntegration_IncrementClicks\` に stats 検証を追加、\`TestIntegration_GetClickStats_Empty\` 新設
- \`api/handler/handler_test.go\`: \`TestStats_Success\` / \`NotFound\` / \`DaysQuery\` 新設、mockStore に \`GetClickStats\` メソッド追加

### web (SvelteKit)
- \`web/src/lib/api.ts\`: \`ClickStats\` / \`DailyClicks\` interface + \`getClickStats\` 関数
- \`web/src/routes/+page.svelte\`: URL 一覧の各行に「統計」ボタン (mobile / desktop 両方)、Dialog で総クリック数 + 過去 30 日の日別リスト (Table、max-h-60 スクロール) を表示

## 旧実装からの改善点

1. **stats table を IaC で定義** (旧実装は terraform 定義漏れ)
2. **DYNAMODB_STATS_TABLE 環境変数で table 名を渡す** (旧実装は \`tableName + \"-stats\"\` ハードコード)
3. **integration test setup で stats table も provision** して全 path をカバー
4. **GetClickStats を \`ScanIndexForward: false\` で日付降順で返す**
5. **Daily slice は make でサイズ事前確保** (旧実装は append)
6. **Stats handler に days パラメータの不正値処理を追加** (TestStats_DaysQuery でカバー)

## Verification

ローカルで全部通っていることを確認済み (\`flox activate\` 配下):

\`\`\`bash
go vet ./...                                  # OK
go build -o /dev/null ./...                   # OK
go test -count=1 ./...                        # all unit tests PASS
go test -tags integration -count=1 ./...      # all integration tests PASS (7+件)
pnpm build                                    # OK
pnpm check                                    # 0 errors, 0 warnings
\`\`\`

旧 #34 で fail していた \`TestIntegration_IncrementClicks\` も今回は緑。

## 関連

- \`#40\`: 本 PR の起票元 issue
- \`#33\` (open): 旧 stack PR の下層、本 PR merge 後に close 予定
- 旧 stack の dangling commits (回収済み): \`0ec7511\` (#33), \`9a77b58\` (#34), \`2668b24\` (#35) — 実装の参考

Fixes #40